### PR TITLE
add mac installer/uninstaller/plist

### DIFF
--- a/installers/mac/com.splintermail.client.plist.recipe
+++ b/installers/mac/com.splintermail.client.plist.recipe
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.splintermail.client</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>PYTHON</string>
+    <string>HOME/.ditm/ditm.py</string>
+    <string>--gpg-bin</string>
+    <string>GPGBIN</string>
+  </array>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardErrorPath</key>
+  <string>HOME/.ditm/ditm_log.stderr</string>
+</dict>
+</plist>

--- a/installers/mac/install.sh
+++ b/installers/mac/install.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# don't run this script as sudo
+if [ "$EUID" -eq 0 ] ; then
+    echo "this script should only be run as a regular user, try again"
+    exit 1
+fi
+
+# check to make sure we have GPG and python
+gpg --version > /dev/null 2>&1 || (echo "gpg not found, please install" && exit)
+python3 --version > /dev/null 2>&1 || (echo "python3 not found, please install" && exit)
+
+# set path to python 3, with pyenv installed special which command should be used
+PYTHON=$(pyenv which python3 2> /dev/null)
+if [ -z $PYTHON ]; then PYTHON=$(which python3); fi
+echo "using python3 located at "$PYTHON
+
+GPGBIN=$(which gpg)
+echo "using gpg located at "$GPGBIN
+
+# first hardcode the current directory into the com.splintermail.client.plist
+# this supports a non-root install
+cat com.splintermail.client.plist.recipe |
+    sed -e 's*PYTHON*'$PYTHON'*' |
+    sed -e 's*GPGBIN*'$GPGBIN'*' |
+    sed -e 's*HOME*'$HOME'*' > com.splintermail.client.plist
+
+# next create the ~/.ditm directory if it does not already exist
+echo "making the ~/.ditm directory"
+mkdir -p "$HOME/.ditm"
+
+echo "copying ditm.py into ~/.ditm"
+cp ../../ditm.py "$HOME/.ditm/"
+
+# now make self-signed certificates for SSL encryption (localhost to localhost only)
+# this doesn't affect security a lot but makes thunderbird offer an SSL exception rather
+# than a giant red "don't do this" warning
+if [ -n "$(which openssl)" ] && \
+    [ -f "$HOME/.ditm/splintermail-snakeoil-cert.pem" ] && \
+     [ -f "$HOME/.ditm/splintermail-snakeoil-cert.pem" ] ; then
+    echo "self-signed local-to-local-only SSL certificates already exist, skipping..."
+else
+    openssl req -x509 -newkey rsa:4096 \
+        -keyout "$HOME/.ditm/splintermail-snakeoil-key.pem" \
+        -out "$HOME/.ditm/splintermail-snakeoil-cert.pem" \
+        -subj '/O=Splintermail Local-only Connection/CN=localhost' -nodes -days 3560
+fi
+
+# copy com.splintermail.client.plist
+echo "copying com.splintermail.client.plist into ~/Library/LaunchAgents/"
+cp `pwd`/com.splintermail.client.plist "$HOME/Library/LaunchAgents/com.splintermail.client.plist"
+
+# load the launch agent
+echo "loading the Launch Agent with launchctl"
+launchctl load -w "$HOME/Library/LaunchAgents/com.splintermail.client.plist"
+
+# copy splintermail to /usr/local/bin
+echo "copying splintermail into /usr/local/bin"
+cp ../../splintermail /usr/local/bin/
+
+# copy command line completions into place
+if [ -d "/usr/local/etc/bash_completion.d/" ] ; then
+    echo "copying bash command line completion file into place"
+    cp ../../cli_completion/bash/splintermail /usr/local/etc/bash_completion.d/
+fi
+
+if [ -d "/usr/local/share/zsh/site-functions" ] ; then
+    echo "copying zsh command line completion file into place"
+    cp ../../cli_completion/zsh/_splintermail /usr/local/share/zsh/site-functions
+fi
+

--- a/installers/mac/uninstall.sh
+++ b/installers/mac/uninstall.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# don't run this script as sudo
+if [ "$EUID" -eq 0 ] ; then
+    echo "this script should only be run as a regular user, try again"
+    exit 1
+fi
+
+# delete the launchctl links
+launchctl unload com.splintermail.client.plist
+rm "$HOME/Library/LaunchAgents/com.splintermail.client.plist"
+
+# delete the com.splintermail.client.plist, leaving only the .recipe
+rm com.splintermail.client.plist
+
+# delete config files and such if they exist
+[ -f "$HOME/.splintermail.gpg" ] && rm $HOME/.splintermail.gpg
+[ -d "$HOME/.ditm" ] && rm -r $HOME/.ditm
+
+# delete /usr/local/bin/splintermail if it exists
+if [ -f "/usr/local/bin/splintermail" ] ; then
+    echo "now deleting splintermail from /usr/local/bin"
+    rm /usr/local/bin/splintermail
+fi
+
+# delete command line completions if they exist
+if [ -f "/usr/local/etc/bash_completion.d/splintermail" ] ; then
+    echo "now deleting bash command line completion file"
+    rm /usr/local/etc/bash_completion.d/splintermail
+fi
+
+if [ -f "/usr/local/share/zsh/site-functions/_splintermail" ] ; then
+    echo "now deleting zsh command line completion file"
+    rm /usr/local/share/zsh/site-functions/_splintermail
+fi
+


### PR DESCRIPTION
As you can see I added an installer for mac complete with a .plist file which is the format used by mac for services. Because of the way mac does services and permissions on various parts of the file system this can be installed entirely without sudo.

I made the choice to copy all script files to installed locations with the install script. This means that unlike the linux that pointed back at the project with symlinks and paths so that if the files are edited they affect the installed use, with this one you would have to run ./install.sh again after making any changes to the scripts.

I've tested the functionality of this on one of my mac computers. I will try it on my other computer in the future. Let me know if there are things you'd like me to change and I can change them before you accept the pull request.